### PR TITLE
Update Rust edition to 2024 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-leetcode"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "rust_leetcode"


### PR DESCRIPTION
Related Issues
closes #50 

PR Description
Updates the Rust edition specified in Cargo.toml from 2021 to 2024.

Changes:
- Modified the edition field in Cargo.toml from "2021" to "2024"
- Verified all existing code remains compatible with the new edition

This update allows the project to benefit from the latest Rust language features and improvements introduced in the 2024 edition, while maintaining backward compatibility with existing code.