### PR TITLE
Add solution for Defanging an IP Address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod numbers;
+pub mod strings;
 pub mod vectors;
 
 pub use numbers::*;
+pub use strings::*;
 pub use vectors::*;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/strings/defanging_an_ip_address.rs
+++ b/src/strings/defanging_an_ip_address.rs
@@ -1,0 +1,33 @@
+/// Defangs an IP address by replacing all "." with "[.]"
+///
+/// # Arguments
+///
+/// * `address` - A valid IP address
+///
+/// # Returns
+///
+/// * `String` - The defanged IP address
+///
+/// # Examples
+///
+/// ```
+/// use rust_leetcode::strings::defang_ip_addr;
+///
+/// let ip = "1.1.1.1";
+/// assert_eq!(defang_ip_addr(ip), String::from("1[.]1[.]1[.]1"));
+/// ```
+#[must_use]
+pub fn defang_ip_addr(address: &str) -> String {
+    address.replace('.', "[.]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        let ip1 = "1.1.1.1";
+        assert_eq!(defang_ip_addr(ip1), String::from("1[.]1[.]1[.]1"));
+    }
+}

--- a/src/strings/mod.rs
+++ b/src/strings/mod.rs
@@ -1,0 +1,2 @@
+mod defanging_an_ip_address;
+pub use defanging_an_ip_address::*;


### PR DESCRIPTION
Related Issues
closes #24 

PR Description
Add a solution for the LeetCode "Defanging an IP Address" problem.

Implementation details:

- Simple and efficient implementation using String's replace method
- Replaces all occurrences of "." with "[.]" in an IP address string
- Annotated with #[must_use] attribute to enforce proper usage
- Comprehensive documentation with examples
- Test coverage for sample cases

This implementation provides a clean and straightforward solution to the problem using Rust's standard library functionality. The function is well-documented with doc comments that include examples of usage.

The use of the #[must_use] attribute ensures that callers don't accidentally discard the return value, promoting better code practices throughout the project.