### PR TITLE
Add solution for Convert Binary Number in a Linked List to Integer

### DIFF
--- a/src/encoding_decoding/convert_binary_number_in_a_linked_list_to_integer.rs
+++ b/src/encoding_decoding/convert_binary_number_in_a_linked_list_to_integer.rs
@@ -1,0 +1,72 @@
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct ListNode {
+    pub val: i32,
+    pub next: Option<Box<ListNode>>,
+}
+
+impl ListNode {
+    #[inline]
+    #[must_use]
+    pub fn new(val: i32) -> Self {
+        ListNode { next: None, val }
+    }
+}
+/// Convert binary number in a linked list to integer
+///
+/// # Arguments
+///
+/// * `head` - The head of the linked list
+///
+/// # Returns
+///
+/// * `Result<i32, &'static str>` - The integer value of the binary number
+///
+/// # Errors
+///
+/// Returns an error message "Head is None" if the input linked list is empty.
+///
+/// # Examples
+///
+/// ```
+/// use rust_leetcode::encoding_decoding::get_decimal_value;
+/// use rust_leetcode::encoding_decoding::ListNode;
+///
+/// assert_eq!(get_decimal_value(Some(Box::new(ListNode::new(1)))), Ok(1));
+/// ```
+pub fn get_decimal_value(head: Option<Box<ListNode>>) -> Result<i32, &'static str> {
+    if head.is_none() {
+        return Err("Head is None");
+    }
+
+    let mut current = head;
+    let mut result = 0;
+
+    while let Some(node) = current {
+        result = (result << 1) | node.val;
+        current = node.next;
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        let mut head = ListNode::new(1);
+        let mut second = ListNode::new(0);
+        let third = ListNode::new(1);
+
+        second.next = Some(Box::new(third));
+        head.next = Some(Box::new(second));
+
+        assert_eq!(get_decimal_value(Some(Box::new(head))), Ok(5));
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        assert_eq!(get_decimal_value(None), Err("Head is None"));
+    }
+}

--- a/src/encoding_decoding/mod.rs
+++ b/src/encoding_decoding/mod.rs
@@ -9,3 +9,6 @@ pub use shuffle_string::*;
 
 mod decode_the_message;
 pub use decode_the_message::*;
+
+mod convert_binary_number_in_a_linked_list_to_integer;
+pub use convert_binary_number_in_a_linked_list_to_integer::*;


### PR DESCRIPTION
Related Issues
closes #33 

PR Description
Adds a solution for the LeetCode "Convert Binary Number in a Linked List to Integer" problem.

Implementation details:
- Convert a binary number, represented as a linked list, to an integer value
- Each node in the linked list contains a single binary digit (0 or 1)
- Process the linked list with a simple iterative approach:
  - Start with result = 0
  - For each node: result = result * 2 + node.val
- Validate input and return appropriate error for empty linked lists
- O(n) time complexity where n is the length of the linked list
- O(1) space complexity as we only use a single variable for computation

The solution efficiently traverses the linked list once, building the decimal
value as it goes. This approach mimics how binary-to-decimal conversion works
mathematically, with each new digit shifting the existing value left (×2) and
then adding the new digit.

Test cases cover both standard scenarios and edge cases like empty lists.

Special Notes
The implementation demonstrates how to handle Option<Box<T>> patterns in Rust
and effectively process linked data structures.