### PR TITLE
Add solution for Count of Matches in Tournament

### DIFF
--- a/src/iterations/count_of_matches_in_tournament.rs
+++ b/src/iterations/count_of_matches_in_tournament.rs
@@ -1,0 +1,43 @@
+/// Count Matches in Tournament
+///
+/// # Arguments
+///
+/// * `n` - Number of teams
+///
+/// # Returns
+///
+/// * `Result<i32, &'static str>` - The number of matches played in the tournament, or an error if the input is invalid
+///
+/// # Errors
+///
+/// Returns an error if the input is invalid.
+///
+/// # Examples
+///
+/// ```
+/// use rust_leetcode::iterations::number_of_matches;
+///
+/// assert_eq!(number_of_matches(7), Ok(6));
+/// ```
+pub fn number_of_matches(n: i32) -> Result<i32, &'static str> {
+    if !(1..=200).contains(&n) {
+        return Err("n must be between 1 and 200");
+    }
+
+    Ok(n - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        assert_eq!(number_of_matches(7), Ok(6));
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        assert_eq!(number_of_matches(0), Err("n must be between 1 and 200"));
+    }
+}

--- a/src/iterations/mod.rs
+++ b/src/iterations/mod.rs
@@ -6,3 +6,6 @@ pub use number_of_steps_to_reduce_a_number_to_zero::*;
 
 mod create_target_array_in_the_given_order;
 pub use create_target_array_in_the_given_order::*;
+
+mod count_of_matches_in_tournament;
+pub use count_of_matches_in_tournament::*;


### PR DESCRIPTION
Related Issues
closes #37 

PR Description
Adds a solution for the LeetCode "Count of Matches in Tournament" problem.

Implementation details:
- Calculate the total number of matches played in an elimination tournament
- Use the mathematical insight that matches = teams - 1:
  - In each match, exactly one team is eliminated
  - Tournament continues until only one champion remains
  - Therefore, from n teams to 1 winner requires eliminating n-1 teams
  - Each elimination requires exactly one match
- Validate input for valid team count range (1-200)
- O(1) time complexity with direct formula calculation
- O(1) space complexity using constant extra space