### PR TITLE
Improve direct indexing with safer options

### DIFF
--- a/src/encoding_decoding/decode_the_message.rs
+++ b/src/encoding_decoding/decode_the_message.rs
@@ -15,6 +15,10 @@ use std::collections::HashMap;
 ///
 /// Returns an error if the key is not valid.
 ///
+/// # Panics
+///
+/// This function will not panic under normal circumstances as all index accesses are checked.
+///
 /// # Examples
 ///
 /// ```
@@ -51,7 +55,12 @@ pub fn decode_message(key: &str, message: &str) -> Result<String, &'static str> 
     let mut index = 0;
     for c in key.chars().filter(|&c| c != ' ') {
         if index < alphabet.len() && !key_chars_map.contains_key(&c) {
-            key_chars_map.insert(c, alphabet[index]);
+            key_chars_map.insert(
+                c,
+                *alphabet
+                    .get(index)
+                    .expect("Safe: index < alphabet.len() is checked above"),
+            );
             index += 1;
         }
     }

--- a/src/encoding_decoding/decompress_run_length_encoded_list.rs
+++ b/src/encoding_decoding/decompress_run_length_encoded_list.rs
@@ -17,6 +17,14 @@ use std::iter::repeat;
 /// - Length of `nums` is odd
 /// - Elements of `nums` is not between 1 and 100 for all `i % 2 == 0`
 ///
+/// # Panics
+///
+/// This function uses `expect()` in the implementation which normally can cause a panic.
+/// However, it is safe here because:
+/// - We validate that `nums.len()` is even and >= 2 before processing
+/// - The `chunks(2)` method guarantees each chunk has exactly 2 elements
+/// - Therefore, `first()` and `last()` will always return `Some(&usize)`
+///
 /// # Examples
 ///
 /// ```
@@ -37,7 +45,15 @@ pub fn decompress_rl_elist(nums: &[usize]) -> Result<Vec<usize>, &'static str> {
 
     Ok(nums
         .chunks(2)
-        .flat_map(|chunk| repeat(chunk[1]).take(chunk[0]))
+        .flat_map(|chunk| {
+            let freq = *chunk
+                .first()
+                .expect("Safe: Array length is validated to be at least 2 and even");
+            let val = *chunk
+                .last()
+                .expect("Safe: Array length is validated to be at least 2 and even");
+            repeat(val).take(freq)
+        })
         .collect())
 }
 

--- a/src/strings/count_items_matching_a_rule.rs
+++ b/src/strings/count_items_matching_a_rule.rs
@@ -17,6 +17,10 @@
 /// Returns an error if `rule_key` is not "type", "color", or "name".
 /// Returns an error if any item doesn't have enough elements (at least 3).
 ///
+/// # Panics
+///
+/// This function will not panic under normal circumstances as all index accesses are checked.
+/// The `expect()` call inside the filter function is safe because we verify all items have sufficient length before processing.
 ///
 /// # Examples
 ///
@@ -52,7 +56,12 @@ pub fn count_matches(
 
     Ok(items
         .iter()
-        .filter(|item| item[rule_key_index] == rule_value)
+        .filter(|item| {
+            *item
+                .get(rule_key_index)
+                .expect("Safe: we already checked all items have sufficient length above")
+                == rule_value
+        })
         .count())
 }
 


### PR DESCRIPTION
## Related Issues
Close #67 

## PR Description

Refactors the `decompress_rl_elist`, `decode_the_message`, `count_items_mathcing_a_rule` function implementation for improved safety and readability.

Implementation details:

- Replace `chunk.get()` with `first()` and `last()` for better semantic clarity
- Use `expect()` with descriptive safety messages instead of `unwrap_or()`
- Add detailed documentation explaining why `expect()` won't panic
- Maintain the same algorithmic efficiency (O(n))
- Enhance code self-documentation through clear error messages

The refactoring preserves the functional style while making the code more maintainable. By using `expect()` with appropriate explanatory messages, the code clearly documents its safety assumptions. This approach makes the implementation both safer and easier to understand for future contributors.
